### PR TITLE
refactor: use newer readonly array syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -228,9 +228,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.12.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.1.tgz",
-      "integrity": "sha512-sKDlqv6COJrR7ar0+GqqhrXQDzQlMcqMnF2iEU6m9hLo8kxozoAGUazwPyELHlRVmjsbvlnGXjnzyptSXVmceA=="
+      "version": "11.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.2.tgz",
+      "integrity": "sha512-c82MtnqWB/CqqK7/zit74Ob8H1dBdV7bK+BcErwtXbe0+nUGkgzq5NTDmRW/pAv2lFtmeNmW95b0zK2hxpeklg=="
     },
     "@types/object-hash": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.5",
-    "@types/node": "^11.12.1",
+    "@types/node": "^11.12.2",
     "@types/object-hash": "^1.2.0",
     "@types/uuid": "^3.4.4",
     "@types/xmldom": "^0.1.29",
@@ -53,7 +53,7 @@
     "rollup": "^1.7.4",
     "rollup-plugin-commonjs": "^9.2.2",
     "rollup-plugin-typescript2": "^0.20.1",
-    "semantic-release": "^15.13.8",
+    "semantic-release": "^15.13.3",
     "ts-node": "^8.0.3",
     "tslint": "^5.14.0",
     "tslint-immutable": "^5.5.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export interface IIPScannerConfig {
    * 255 addresses to scan (0...255)
    * ex: ['10.211.55', '44.55.11']
    */
-  readonly PREFIXES: ReadonlyArray<string>
+  readonly PREFIXES: readonly string[]
 
   /**
    * List of ip address to scan
@@ -21,7 +21,7 @@ export interface IIPScannerConfig {
    * found on the local machine
    * ex: ['10.211.55.10', '44.55.11.15']
    */
-  readonly IP_ADDRESSES: ReadonlyArray<string>
+  readonly IP_ADDRESSES: readonly string[]
 }
 
 /**
@@ -31,7 +31,7 @@ export interface IProbeConfig {
   /**
    * Ports to broadcast to.
    */
-  readonly PORTS: ReadonlyArray<number>
+  readonly PORTS: readonly number[]
 
   /**
    * IP based scanning
@@ -62,7 +62,7 @@ export interface IProbeConfig {
   /**
    * ONVIF device types to check for.
    */
-  readonly ONVIF_DEVICES: ReadonlyArray<string>
+  readonly ONVIF_DEVICES: readonly string[]
 
   /**
    * An object the conforms to the W3C DOMParser spec. This helps parse respnse XML.

--- a/src/device.ts
+++ b/src/device.ts
@@ -6,7 +6,7 @@ export interface IONVIFDevice {
   readonly metadataVersion: string
   readonly deviceServiceUri: string
   readonly ip: string
-  readonly profiles: ReadonlyArray<string>
-  readonly xaddrs: ReadonlyArray<string>
-  readonly scopes: ReadonlyArray<string>
+  readonly profiles: readonly string[]
+  readonly xaddrs: readonly string[]
+  readonly scopes: readonly string[]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,10 @@ export { IONVIFDevice }
 export { DEFAULT_CONFIG }
 
 const uniqueObjects =
-  (arr: ReadonlyArray<any>) =>
+  (arr: readonly any[]) =>
     arr.filter((object, index) => index === arr.findIndex(obj => JSON.stringify(obj) === JSON.stringify(object)))
 
-type ProbeStream = Observable<ReadonlyArray<IONVIFDevice>>
+type ProbeStream = Observable<readonly IONVIFDevice[]>
 
 export const probeONVIFDevices = () => reader<Partial<IProbeConfig>, ProbeStream>(partialConfig => {
   const config: IProbeConfig = { ...DEFAULT_CONFIG, ...partialConfig }
@@ -50,7 +50,7 @@ export const probeONVIFDevices = () => reader<Partial<IProbeConfig>, ProbeStream
       map(xmlResponse => xmlResponse
         .map(xmlString => config.DOM_PARSER.parseFromString(xmlString, 'application/xml'))
         .map(xmlDoc => parseXmlResponse(xmlDoc)(config))),
-      mergeScan<IMaybe<IONVIFDevice>, ReadonlyArray<IONVIFDevice>>((acc, curr) => {
+      mergeScan<IMaybe<IONVIFDevice>, readonly IONVIFDevice[]>((acc, curr) => {
         return forkJoin([...acc, curr.valueOrUndefined() as IONVIFDevice].filter(Boolean).map(device => ping(device.ip)()(config.PROBE_NETWORK_TIMEOUT_MS).pipe(
           map(v => v.isOk()
             ? { include: true, device }

--- a/src/ipscan.ts
+++ b/src/ipscan.ts
@@ -12,7 +12,7 @@ export const getIpPrefixListFromNetworkInterfaces = (family: 'IPv4' | 'IPv6' = '
   const interfaceDict = networkInterfaces()
 
   return Object.keys(interfaceDict)
-    .reduce((acc: ReadonlyArray<NetworkInterfaceInfo>, curr) => [...acc, ...interfaceDict[curr]], [])
+    .reduce((acc: readonly NetworkInterfaceInfo[], curr) => [...acc, ...interfaceDict[curr]], [])
     .filter(a => a.family === family && !a.internal)
     .map(c => c.address.split('.').slice(0, 3).join('.'))
 }
@@ -21,8 +21,8 @@ export const getIpPrefixListFromNetworkInterfaces = (family: 'IPv4' | 'IPv6' = '
 export const combined = (...args: string[][]) => args.reduce((acc, curr) => [...acc, ...curr], [])
 
 export const ipscan =
-  (ipAddressPrefixes: ReadonlyArray<string> = []) =>
-    (ipAddresses: ReadonlyArray<string> = []) => {
+  (ipAddressPrefixes: readonly string[] = []) =>
+    (ipAddresses: readonly string[] = []) => {
       const standard = getIpPrefixListFromNetworkInterfaces().map(getIpRangeFromPrefix())
       const pref = ipAddressPrefixes.map(getIpRangeFromPrefix())
       // tslint:disable-next-line:readonly-array

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -18,7 +18,7 @@ export const parseXmlResponse = (doc: Document) => (config: IProbeConfig): IONVI
     const parseProbeDiscoveryElements = parseProbeElements(SCHEMAS.discovery)
     const parseProbeAddressingElements = parseProbeElements(SCHEMAS.addressing)
 
-    const scopeParser = (scopes: ReadonlyArray<string>) => (pattern: string) =>
+    const scopeParser = (scopes: readonly string[]) => (pattern: string) =>
       maybe(scopes.find(a => a.toLowerCase().includes(`onvif://www.onvif.org/${pattern}`.toLocaleLowerCase()))).flatMapAuto(a => a.split('/').pop())
 
     const scopes = parseProbeDiscoveryElements('Scopes').flatMapAuto(a => a.textContent).map(a => a.split(' ')).valueOr([])


### PR DESCRIPTION
BREAKING CHANGE: now requires Typescript 3.4.1 or higher as of v4.0.2 of this library.